### PR TITLE
update pathing for new binary name, upate icon location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN \
     "${YAAK_URL}" && \
   apt-get install -y --no-install-recommends \
     /tmp/yaak.deb && \
+  ln -s \
+    /usr/bin/yaak-app-client \
+    /usr/bin/yaak-app && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \
   apt-get clean && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -34,6 +34,9 @@ RUN \
     "${YAAK_URL}" && \
   apt-get install -y --no-install-recommends \
     /tmp/yaak.deb && \
+  ln -s \
+    /usr/bin/yaak-app-client \
+    /usr/bin/yaak-app && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \
   apt-get clean && \

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
-<item label="Yaak" icon="/usr/share/icons/hicolor/256x256@2/apps/yaak-app.png"><action name="Execute"><command>/usr/bin/yaak-app</command></action></item>
+<item label="Yaak" icon="/usr/share/icons/hicolor/256x256@2/apps/yaak-app-client.png"><action name="Execute"><command>/usr/bin/yaak-app</command></action></item>
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
 </menu>
 </openbox_menu>

--- a/root/defaults/menu_wayland.xml
+++ b/root/defaults/menu_wayland.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
-<item label="Yaak" icon="/usr/share/icons/hicolor/256x256@2/apps/yaak-app.png"><action name="Execute"><command>/usr/bin/yaak-app</command></action></item>
+<item label="Yaak" icon="/usr/share/icons/hicolor/256x256@2/apps/yaak-app-client.png"><action name="Execute"><command>/usr/bin/yaak-app</command></action></item>
 <item label="foot" icon="/usr/share/icons/hicolor/48x48/apps/foot.png"><action name="Execute"><command>/usr/bin/foot</command></action></item>
 </menu>
 </openbox_menu>


### PR DESCRIPTION
Saw a black ci report, they changed the bin name to yaak-app-client, this symlinks at build time so old autostarts and menus work and updates new deployments to use the correct icon path. 

I did not include a changelog as I did not see a great reason. 